### PR TITLE
[FEAT] 프로필 사진 삭제 API 개발

### DIFF
--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 
 import User from "../models/user.model.js";
 import cloudinary from "../configs/cloudinary.js";
+import mongoose from "mongoose";
 
 export const updateProfile = async (req, res) => {
   const userId = req.user._id;
@@ -58,10 +59,27 @@ export const updateProfile = async (req, res) => {
 
     //변경3 - 프로필 이미지를 변경하고자 할 경우
     if (newProfileImg) {
-      const response = await cloudinary.uploader.upload(newProfileImg);
-      newProfileImg = response.secure_url;
+      //기존 프로필 사진이 있다면 제거
+      const initialImgPublicId = req.user.profileImg?.publicId;
 
-      updateData.profileImg = newProfileImg;
+      if (initialImgPublicId) {
+        await cloudinary.uploader.destroy(initialImgPublicId, {
+          invalidate: true,
+        });
+      }
+
+      //이미지 추가
+      const response = await cloudinary.uploader.upload(newProfileImg, {
+        folder: "user_profile",
+      });
+
+      newProfileImg = response.secure_url;
+      const publicId = response.public_id;
+
+      updateData.profileImg = {
+        url: newProfileImg,
+        publicId: publicId,
+      };
     }
 
     //변경사항이 없을 때 == updateData가 빈 객체일 경우 처리
@@ -91,5 +109,57 @@ export const updateProfile = async (req, res) => {
     res.status(500).json({
       error: "internal server error...",
     });
+  }
+};
+
+//프로필 이미지 삭제
+export const deleteProfileImg = async (req, res) => {
+  //트랜잭션 시작
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
+  try {
+    const userId = req.user._id;
+    const user = await User.findById(userId).session(session);
+    const imgPublicId = user.profileImg?.publicId;
+
+    if (!imgPublicId) {
+      await session.abortTransaction();
+      return res
+        .status(400)
+        .json({ error: "삭제할 프로필 이미지가 없습니다." });
+    }
+
+    //DB삭제 먼저 시도 - because. cloudinary는 rollback불가능
+    const updatedUser = await User.findByIdAndUpdate(
+      user._id,
+      { $set: { profileImg: { url: "", publicId: "" } } },
+      { session: session, new: true }
+    ).select("-password");
+
+    // cloudinary에서 삭제
+    const cloudinaryResult = await cloudinary.uploader.destroy(imgPublicId, {
+      invalidate: true, //CDN에서도 제거
+    });
+
+    if (cloudinaryResult.result !== "ok") {
+      // Cloudinary 삭제가 실패하면 에러를 던짐, catch에서 DB 작업 롤백
+      throw new Error("Cloudinary 삭제 실패");
+    }
+
+    //트랜잭션 커밋
+    await session.commitTransaction();
+
+    res.status(200).json({
+      message: "프로필 사진을 기본 이미지로 변경했어요.",
+      user: updatedUser,
+    });
+  } catch (error) {
+    await session.abortTransaction();
+    console.error(`트랜잭션 롤백됨: ${error}`);
+
+    res.status(500).json({ error: "internal server error..." });
+  } finally {
+    session.endSession();
   }
 };

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -17,8 +17,8 @@ const userSchema = new mongoose.Schema(
       minlength: 8,
     },
     profileImg: {
-      type: String,
-      default: "",
+      url: { type: String, default: "" },
+      publicId: { type: String, default: "" },
     },
     passwordWrongCount: {
       type: Number,

--- a/backend/src/routes/user.route.js
+++ b/backend/src/routes/user.route.js
@@ -1,10 +1,14 @@
 import express from "express";
 
 import protectedRoute from "../middleware/protectedRoute.js";
-import { updateProfile } from "../controllers/user.controller.js";
+import {
+  deleteProfileImg,
+  updateProfile,
+} from "../controllers/user.controller.js";
 
 const router = express.Router();
 
 router.patch("/profile", protectedRoute, updateProfile);
+router.delete("/profile-img", protectedRoute, deleteProfileImg);
 
 export default router;


### PR DESCRIPTION
# 개발(변경)사항 

## 1.  `cloudinary.uploader.destroy()` 의 인자로 `public_id` 를 전달하기 위해 user모델 스키마 및 updateProfile함수의 로직 일부 변경
  
FROM 
` profileImg: {
      type: String, default: "" 
    },`

TO
` profileImg: {
      url: { type: String, default: "" },
      publicId: { type: String, default: "" },
    },`

## 2. cloudinary의 destroy가 rollback불가이므로, mongoDB의 profileImg삭제와 destroy를 하나의 트랜잭션으로 묶음, DB삭제를 먼저 수행 후, 처리 성공시에만 cloudinary삭제 로직을 수행하도록 설정. 

Closes #7 